### PR TITLE
bugfix: will overwrite dat file if it exists

### DIFF
--- a/cnda_dl/cli.py
+++ b/cnda_dl/cli.py
@@ -250,6 +250,8 @@ def dat_dcm_to_nifti(session: str,
         series_id = uid_to_id[uid]
         series_path = session_dicom_dir / series_id / "DICOM"
         for dat in dats:
+            if (series_path / dat).is_file():
+                (series_path / dat).unlink()
             shutil.move(dat.resolve(), series_path.resolve())
 
         # Either there are no accompanying dats, or they were already in the series directory


### PR DESCRIPTION
this commit fixes a bug that arises when attempting to copy a .dat file to a DICOM directory if the .dat file exists in that directory -- this ensures that a corrupted .dat file isn't ignored if it exists